### PR TITLE
- return is more polite than exit when terminal is dump.

### DIFF
--- a/scripts/bashrc
+++ b/scripts/bashrc
@@ -1,5 +1,5 @@
 if [ ${TERM} == "dumb" ]; then
-    exit 0
+    return
 fi
 
 


### PR DESCRIPTION
- with exit commands like scp, rsync or ssh root@<host> "ls -l" to the cubietruck fails.
